### PR TITLE
add python-psycopg2 to packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
   with_items:
     - postgresql
     - libpq-dev
+    - python-psycopg2
     - python3-psycopg2
 
 


### PR DESCRIPTION
I had to add the `python-psycopg2` package to the requirements here because Ansible itself required this on remote host before it could use the `postgresql_db` module.  I'm not sure if this is the best place to put this, though?